### PR TITLE
Removed required files from .npmignore

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,5 +1,4 @@
 node_modules
-src
 .DS_Store
 build
 !.eslintrc


### PR DESCRIPTION
The src folder is required in the library.
When it is removed, it gives rise to the error below:

```
Error: Cannot find module './cognito'
    at Function.Module._resolveFilename (module.js:548:15)
    at Function.Module._load (module.js:475:25)
    at Module.require (module.js:597:17)
    at require (internal/module.js:11:18)
    at Object.<anonymous> (/node_modules/aws-cognito-token-generator/src/index.js:2:17)
    at Module._compile (module.js:653:30)
    at Object.Module._extensions..js (module.js:664:10)
    at Module.load (module.js:566:32)
    at tryModuleLoad (module.js:506:12)
    at Function.Module._load (module.js:498:3)
```